### PR TITLE
Removes `pointer-events: none;` in the style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,6 +9,10 @@
     pointer-events: none;
   }
 
+  gaia-drawer[open] {
+    pointer-events: auto;
+  }
+
   /** Inner
    ---------------------------------------------------------*/
 


### PR DESCRIPTION
It seems that this stylesheet will cause the drawer unable to be closed if the user click on the background.
